### PR TITLE
Update pom for newer mvn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
On my system I have Java 11 and 8 on my system and `mvn` depends on 11. This line is needed to indicate that you want to use 8: https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#release otherwise the build fails.

This will need maven `>= 3.6`. This may not be necessary if you only have 8 on your system. Happy to move this to a README if having multiple Java versions is not a common.